### PR TITLE
Change property label "Plaats" to "plaats" + fix hash URIs Persoon Voc

### DIFF
--- a/ns/generiek.html
+++ b/ns/generiek.html
@@ -462,7 +462,7 @@
     <p>
         |
         
-        <a href="#http://data.vlaanderen.be/ns/generiek#plaats" rel="property">Plaats (Jurisdictie)</a> |
+        <a href="#http://data.vlaanderen.be/ns/generiek#plaats" rel="property">plaats (Jurisdictie)</a> |
         
         <a href="#http://data.vlaanderen.be/ns/generiek#begin" rel="property">begin (TijdsInterval)</a> |
         

--- a/ns/persoon.html
+++ b/ns/persoon.html
@@ -546,51 +546,51 @@
     <p>
         |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Afstamming" rel="class">Afstamming</a> |
+        <a href="#Afstamming" rel="class">Afstamming</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#BurgerlijkeStaat" rel="class">Burgerlijke Staat</a> |
+        <a href="#BurgerlijkeStaat" rel="class">Burgerlijke Staat</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Domicilie" rel="class">Domicilie</a> |
+        <a href="#Domicilie" rel="class">Domicilie</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Geboorte" rel="class">Geboorte</a> |
+        <a href="#Geboorte" rel="class">Geboorte</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#GeenInwoner" rel="class">Geen Inwoner</a> |
+        <a href="#GeenInwoner" rel="class">Geen Inwoner</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#GeregistreerdPersoon" rel="class">Geregistreerd Persoon</a> |
+        <a href="#GeregistreerdPersoon" rel="class">Geregistreerd Persoon</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Gezin" rel="class">Gezin</a> |
+        <a href="#Gezin" rel="class">Gezin</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Gezinsrelatie" rel="class">Gezinsrelatie</a> |
+        <a href="#Gezinsrelatie" rel="class">Gezinsrelatie</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Huwelijk" rel="class">Huwelijk</a> |
+        <a href="#Huwelijk" rel="class">Huwelijk</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Inwoner" rel="class">Inwoner</a> |
+        <a href="#Inwoner" rel="class">Inwoner</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Inwonerschap" rel="class">Inwonerschap</a> |
+        <a href="#Inwonerschap" rel="class">Inwonerschap</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Nationaliteit" rel="class">Nationaliteit</a> |
+        <a href="#Nationaliteit" rel="class">Nationaliteit</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Overlijden" rel="class">Overlijden</a> |
+        <a href="#Overlijden" rel="class">Overlijden</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#PermanentInwoner" rel="class">Permanent Inwoner</a> |
+        <a href="#PermanentInwoner" rel="class">Permanent Inwoner</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Persoonsgebeurtenis" rel="class">Persoonsgebeurtenis</a> |
+        <a href="#Persoonsgebeurtenis" rel="class">Persoonsgebeurtenis</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Persoonsrelatie" rel="class">Persoonsrelatie</a> |
+        <a href="#Persoonsrelatie" rel="class">Persoonsrelatie</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Samenwonen" rel="class">Samenwonen</a> |
+        <a href="#Samenwonen" rel="class">Samenwonen</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Staatsburgerschap" rel="class">Staatburgerschap</a> |
+        <a href="#Staatsburgerschap" rel="class">Staatburgerschap</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Staatsburger" rel="class">Staatsburger</a> |
+        <a href="#Staatsburger" rel="class">Staatsburger</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#TijdelijkInwoner" rel="class">Tijdelijk Inwoner</a> |
+        <a href="#TijdelijkInwoner" rel="class">Tijdelijk Inwoner</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Verblijfplaats" rel="class">Verblijfplaats</a> |
+        <a href="#Verblijfplaats" rel="class">Verblijfplaats</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Voogdij" rel="class">Voogdij</a> |
+        <a href="#Voogdij" rel="class">Voogdij</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Vreemdeling" rel="class">Vreemdeling</a> |
+        <a href="#Vreemdeling" rel="class">Vreemdeling</a> |
         
     </p>
     </div>
@@ -606,55 +606,55 @@
     <p>
         |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#datumVanAfstamming" rel="property">Datum Van Afstamming (Afstamming)</a> |
+        <a href="#datumVanAfstamming" rel="property">Datum Van Afstamming (Afstamming)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#afstammingsType" rel="property">Type Afstamming (Afstamming)</a> |
+        <a href="#afstammingsType" rel="property">Type Afstamming (Afstamming)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Staatsburgerschap.binnenJurisdictie" rel="property">binnen jurisdictie (Staatburgerschap)</a> |
+        <a href="#Staatsburgerschap.binnenJurisdictie" rel="property">binnen jurisdictie (Staatburgerschap)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#Inwonerschap.binnenJurisdictie" rel="property">binnen jurisdictie (Inwonerschap)</a> |
+        <a href="#Inwonerschap.binnenJurisdictie" rel="property">binnen jurisdictie (Inwonerschap)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#datum" rel="property">datum (Persoonsgebeurtenis)</a> |
+        <a href="#datum" rel="property">datum (Persoonsgebeurtenis)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam" rel="property">gebruikte voornaam (Persoon)</a> |
+        <a href="#gebruikteVoornaam" rel="property">gebruikte voornaam (Persoon)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#geslacht" rel="property">geslacht (Persoon)</a> |
+        <a href="#geslacht" rel="property">geslacht (Persoon)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#gezinsadres" rel="property">gezinsadres (Gezin)</a> |
+        <a href="#gezinsadres" rel="property">gezinsadres (Gezin)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#gezinsrelatietype" rel="property">gezinsrelatietype (Gezinsrelatie)</a> |
+        <a href="#gezinsrelatietype" rel="property">gezinsrelatietype (Gezinsrelatie)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#heeftBurgerlijkeStaat" rel="property">heeft burgerlijke staat (Persoon)</a> |
+        <a href="#heeftBurgerlijkeStaat" rel="property">heeft burgerlijke staat (Persoon)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#heeftGeboorte" rel="property">heeft geboorte (Persoon)</a> |
+        <a href="#heeftGeboorte" rel="property">heeft geboorte (Persoon)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#heeftInwonerschap" rel="property">heeft inwonerschap (Persoon)</a> |
+        <a href="#heeftInwonerschap" rel="property">heeft inwonerschap (Persoon)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#heeftNationaliteit" rel="property">heeft nationaliteit (Persoon)</a> |
+        <a href="#heeftNationaliteit" rel="property">heeft nationaliteit (Persoon)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#heeftOverlijden" rel="property">heeft overlijden (Persoon)</a> |
+        <a href="#heeftOverlijden" rel="property">heeft overlijden (Persoon)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#heeftPersoonsrelatie" rel="property">heeft persoonsrelatie (Persoon)</a> |
+        <a href="#heeftPersoonsrelatie" rel="property">heeft persoonsrelatie (Persoon)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#heeftStaatsburgerschap" rel="property">heeft staatsburgerschap (Persoon)</a> |
+        <a href="#heeftStaatsburgerschap" rel="property">heeft staatsburgerschap (Persoon)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#heeftVerblijfplaats" rel="property">heeft verblijfplaats (Inwonerschap)</a> |
+        <a href="#heeftVerblijfplaats" rel="property">heeft verblijfplaats (Inwonerschap)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#isHoofdVan" rel="property">is hoofd van (Persoon)</a> |
+        <a href="#isHoofdVan" rel="property">is hoofd van (Persoon)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#isLidVan" rel="property">is lid van (Persoon)</a> |
+        <a href="#isLidVan" rel="property">is lid van (Persoon)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#isRelatieMet" rel="property">is relatie met (Persoonsrelatie)</a> |
+        <a href="#isRelatieMet" rel="property">is relatie met (Persoonsrelatie)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#plaats" rel="property">plaats (Persoonsgebeurtenis)</a> |
+        <a href="#plaats" rel="property">plaats (Persoonsgebeurtenis)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#registratie" rel="property">registratie (Geregistreerd Persoon)</a> |
+        <a href="#registratie" rel="property">registratie (Geregistreerd Persoon)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#type" rel="property">type (Burgerlijke Staat)</a> |
+        <a href="#type" rel="property">type (Burgerlijke Staat)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#verblijfsadres" rel="property">verblijfsadres (Verblijfplaats)</a> |
+        <a href="#verblijfsadres" rel="property">verblijfsadres (Verblijfplaats)</a> |
         
-        <a href="#http://data.vlaanderen.be/ns/persoon#volledigeNaam" rel="property">volledige naam (Persoon)</a> |
+        <a href="#volledigeNaam" rel="property">volledige naam (Persoon)</a> |
         
     </p>
     </div>
@@ -680,7 +680,7 @@
     
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Afstamming">Klasse <em>Afstamming</em></h3>
+    <h3 class="h3" id="Afstamming">Klasse <em>Afstamming</em></h3>
 
     <table class="definition">
         <tbody>
@@ -704,7 +704,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#BurgerlijkeStaat">Klasse <em>Burgerlijke Staat</em></h3>
+    <h3 class="h3" id="BurgerlijkeStaat">Klasse <em>Burgerlijke Staat</em></h3>
 
     <table class="definition">
         <tbody>
@@ -728,7 +728,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Domicilie">Klasse <em>Domicilie</em></h3>
+    <h3 class="h3" id="Domicilie">Klasse <em>Domicilie</em></h3>
 
     <table class="definition">
         <tbody>
@@ -752,7 +752,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Geboorte">Klasse <em>Geboorte</em></h3>
+    <h3 class="h3" id="Geboorte">Klasse <em>Geboorte</em></h3>
 
     <table class="definition">
         <tbody>
@@ -776,7 +776,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#GeenInwoner">Klasse <em>Geen Inwoner</em></h3>
+    <h3 class="h3" id="GeenInwoner">Klasse <em>Geen Inwoner</em></h3>
 
     <table class="definition">
         <tbody>
@@ -800,7 +800,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#GeregistreerdPersoon">Klasse <em>Geregistreerd Persoon</em></h3>
+    <h3 class="h3" id="GeregistreerdPersoon">Klasse <em>Geregistreerd Persoon</em></h3>
 
     <table class="definition">
         <tbody>
@@ -824,7 +824,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Gezin">Klasse <em>Gezin</em></h3>
+    <h3 class="h3" id="Gezin">Klasse <em>Gezin</em></h3>
 
     <table class="definition">
         <tbody>
@@ -848,7 +848,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Gezinsrelatie">Klasse <em>Gezinsrelatie</em></h3>
+    <h3 class="h3" id="Gezinsrelatie">Klasse <em>Gezinsrelatie</em></h3>
 
     <table class="definition">
         <tbody>
@@ -872,7 +872,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Huwelijk">Klasse <em>Huwelijk</em></h3>
+    <h3 class="h3" id="Huwelijk">Klasse <em>Huwelijk</em></h3>
 
     <table class="definition">
         <tbody>
@@ -896,7 +896,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Inwoner">Klasse <em>Inwoner</em></h3>
+    <h3 class="h3" id="Inwoner">Klasse <em>Inwoner</em></h3>
 
     <table class="definition">
         <tbody>
@@ -920,7 +920,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Inwonerschap">Klasse <em>Inwonerschap</em></h3>
+    <h3 class="h3" id="Inwonerschap">Klasse <em>Inwonerschap</em></h3>
 
     <table class="definition">
         <tbody>
@@ -944,7 +944,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Nationaliteit">Klasse <em>Nationaliteit</em></h3>
+    <h3 class="h3" id="Nationaliteit">Klasse <em>Nationaliteit</em></h3>
 
     <table class="definition">
         <tbody>
@@ -968,7 +968,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Overlijden">Klasse <em>Overlijden</em></h3>
+    <h3 class="h3" id="Overlijden">Klasse <em>Overlijden</em></h3>
 
     <table class="definition">
         <tbody>
@@ -992,7 +992,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#PermanentInwoner">Klasse <em>Permanent Inwoner</em></h3>
+    <h3 class="h3" id="PermanentInwoner">Klasse <em>Permanent Inwoner</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1016,7 +1016,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Persoonsgebeurtenis">Klasse <em>Persoonsgebeurtenis</em></h3>
+    <h3 class="h3" id="Persoonsgebeurtenis">Klasse <em>Persoonsgebeurtenis</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1040,7 +1040,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Persoonsrelatie">Klasse <em>Persoonsrelatie</em></h3>
+    <h3 class="h3" id="Persoonsrelatie">Klasse <em>Persoonsrelatie</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1064,7 +1064,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Samenwonen">Klasse <em>Samenwonen</em></h3>
+    <h3 class="h3" id="Samenwonen">Klasse <em>Samenwonen</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1088,7 +1088,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Staatsburgerschap">Klasse <em>Staatburgerschap</em></h3>
+    <h3 class="h3" id="Staatsburgerschap">Klasse <em>Staatburgerschap</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1112,7 +1112,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Staatsburger">Klasse <em>Staatsburger</em></h3>
+    <h3 class="h3" id="Staatsburger">Klasse <em>Staatsburger</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1136,7 +1136,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#TijdelijkInwoner">Klasse <em>Tijdelijk Inwoner</em></h3>
+    <h3 class="h3" id="TijdelijkInwoner">Klasse <em>Tijdelijk Inwoner</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1160,7 +1160,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Verblijfplaats">Klasse <em>Verblijfplaats</em></h3>
+    <h3 class="h3" id="Verblijfplaats">Klasse <em>Verblijfplaats</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1184,7 +1184,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Voogdij">Klasse <em>Voogdij</em></h3>
+    <h3 class="h3" id="Voogdij">Klasse <em>Voogdij</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1208,7 +1208,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Vreemdeling">Klasse <em>Vreemdeling</em></h3>
+    <h3 class="h3" id="Vreemdeling">Klasse <em>Vreemdeling</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1253,7 +1253,7 @@
     
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#datumVanAfstamming">Eigenschap <em>Datum Van Afstamming</em></h3>
+    <h3 class="h3" id="datumVanAfstamming">Eigenschap <em>Datum Van Afstamming</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1289,7 +1289,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#afstammingsType">Eigenschap <em>Type Afstamming</em></h3>
+    <h3 class="h3" id="afstammingsType">Eigenschap <em>Type Afstamming</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1325,7 +1325,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Staatsburgerschap.binnenJurisdictie">Eigenschap <em>binnen jurisdictie</em></h3>
+    <h3 class="h3" id="Staatsburgerschap.binnenJurisdictie">Eigenschap <em>binnen jurisdictie</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1361,7 +1361,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#Inwonerschap.binnenJurisdictie">Eigenschap <em>binnen jurisdictie</em></h3>
+    <h3 class="h3" id="Inwonerschap.binnenJurisdictie">Eigenschap <em>binnen jurisdictie</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1397,7 +1397,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#datum">Eigenschap <em>datum</em></h3>
+    <h3 class="h3" id="datum">Eigenschap <em>datum</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1433,7 +1433,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam">Eigenschap <em>gebruikte voornaam</em></h3>
+    <h3 class="h3" id="gebruikteVoornaam">Eigenschap <em>gebruikte voornaam</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1469,7 +1469,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#geslacht">Eigenschap <em>geslacht</em></h3>
+    <h3 class="h3" id="geslacht">Eigenschap <em>geslacht</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1505,7 +1505,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#gezinsadres">Eigenschap <em>gezinsadres</em></h3>
+    <h3 class="h3" id="gezinsadres">Eigenschap <em>gezinsadres</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1541,7 +1541,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#gezinsrelatietype">Eigenschap <em>gezinsrelatietype</em></h3>
+    <h3 class="h3" id="gezinsrelatietype">Eigenschap <em>gezinsrelatietype</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1577,7 +1577,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#heeftBurgerlijkeStaat">Eigenschap <em>heeft burgerlijke staat</em></h3>
+    <h3 class="h3" id="heeftBurgerlijkeStaat">Eigenschap <em>heeft burgerlijke staat</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1613,7 +1613,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#heeftGeboorte">Eigenschap <em>heeft geboorte</em></h3>
+    <h3 class="h3" id="heeftGeboorte">Eigenschap <em>heeft geboorte</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1649,7 +1649,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#heeftInwonerschap">Eigenschap <em>heeft inwonerschap</em></h3>
+    <h3 class="h3" id="heeftInwonerschap">Eigenschap <em>heeft inwonerschap</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1685,7 +1685,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#heeftNationaliteit">Eigenschap <em>heeft nationaliteit</em></h3>
+    <h3 class="h3" id="heeftNationaliteit">Eigenschap <em>heeft nationaliteit</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1721,7 +1721,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#heeftOverlijden">Eigenschap <em>heeft overlijden</em></h3>
+    <h3 class="h3" id="heeftOverlijden">Eigenschap <em>heeft overlijden</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1757,7 +1757,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#heeftPersoonsrelatie">Eigenschap <em>heeft persoonsrelatie</em></h3>
+    <h3 class="h3" id="heeftPersoonsrelatie">Eigenschap <em>heeft persoonsrelatie</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1793,7 +1793,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#heeftStaatsburgerschap">Eigenschap <em>heeft staatsburgerschap</em></h3>
+    <h3 class="h3" id="heeftStaatsburgerschap">Eigenschap <em>heeft staatsburgerschap</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1829,7 +1829,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#heeftVerblijfplaats">Eigenschap <em>heeft verblijfplaats</em></h3>
+    <h3 class="h3" id="heeftVerblijfplaats">Eigenschap <em>heeft verblijfplaats</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1865,7 +1865,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#isHoofdVan">Eigenschap <em>is hoofd van</em></h3>
+    <h3 class="h3" id="isHoofdVan">Eigenschap <em>is hoofd van</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1901,7 +1901,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#isLidVan">Eigenschap <em>is lid van</em></h3>
+    <h3 class="h3" id="isLidVan">Eigenschap <em>is lid van</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1937,7 +1937,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#isRelatieMet">Eigenschap <em>is relatie met</em></h3>
+    <h3 class="h3" id="isRelatieMet">Eigenschap <em>is relatie met</em></h3>
 
     <table class="definition">
         <tbody>
@@ -1973,7 +1973,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#plaats">Eigenschap <em>plaats</em></h3>
+    <h3 class="h3" id="plaats">Eigenschap <em>plaats</em></h3>
 
     <table class="definition">
         <tbody>
@@ -2009,7 +2009,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#registratie">Eigenschap <em>registratie</em></h3>
+    <h3 class="h3" id="registratie">Eigenschap <em>registratie</em></h3>
 
     <table class="definition">
         <tbody>
@@ -2045,7 +2045,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#type">Eigenschap <em>type</em></h3>
+    <h3 class="h3" id="type">Eigenschap <em>type</em></h3>
 
     <table class="definition">
         <tbody>
@@ -2081,7 +2081,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#verblijfsadres">Eigenschap <em>verblijfsadres</em></h3>
+    <h3 class="h3" id="verblijfsadres">Eigenschap <em>verblijfsadres</em></h3>
 
     <table class="definition">
         <tbody>
@@ -2117,7 +2117,7 @@
       
     
     <div class="region region--no-space-top">
-    <h3 class="h3" id="http://data.vlaanderen.be/ns/persoon#volledigeNaam">Eigenschap <em>volledige naam</em></h3>
+    <h3 class="h3" id="volledigeNaam">Eigenschap <em>volledige naam</em></h3>
 
     <table class="definition">
         <tbody>


### PR DESCRIPTION
In de HTML specificaties voor het vocabularium "generiek" stond de eigenschap plaats als "Plaats" i.p.v. "plaats".