### PR TITLE
Update link van URI standaard

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,7 +270,7 @@
 
 					<p>Centraal in de URI-standaard staan een aantal vormregels die omschrijven op welke wijze een URI moet gevormd worden om te dienen als identificator voor data. Gebruik makend van de vormregels voor URI’s licht de URI-standaard een lijst van resource-classificaties toe. Die moeten alle resource-aanbieders binnen de Vlaamse overheden gebruiken bij het opzetten van nieuwe URI’s om hun resources uniek en persistent te ontsluiten.</p>
 					<br>
-					<a class="link--icon--caret link--block" href="https://overheid.vlaanderen.be/OSLO-URI-standaard">Ontdek hier meer over de Vlaamse URI standaard.</a><br>
+					<a class="link--icon--caret link--block" href="https://overheid.vlaanderen.be/sites/default/files/documenten/ict-egov/e-governement/open-data/VlaamseURI-StandaardVoorData_V1.0.pdf">Ontdek hier meer over de Vlaamse URI standaard.</a><br>
 
 
 					<h3 class="h3">OSLO&#178; Specificaties (kandidaat-standaarden)</h3>


### PR DESCRIPTION
Door aanpassingen op OSLO productpagina was er een broken link ontstaan.